### PR TITLE
Update power script to use gpiod instead of obsolete interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,17 @@
 # XScript
+
 This is script installation tutorial for `NASPi`, `NASPi Gemini 2.5`, `NASPi CM4-M2` and `NASPi CM4-2.5`.
-***
+
+---
+
 The original pwm fan control script is from [pimlie/geekworm-x-c1](https://github.com/pimlie/geekworm-x-c1), **pimlie** implements the pwm fan shell script, which does not depend on third-party python libraries at all. Thanks to **pimlie**.
 
 User Guide: https://wiki.geekworm.com/XScript
 
-Email：support@geekworm.com
+To use the power script, you need to install the gpiod package.
 
+```
+sudo apt install gpiod
+```
+
+Email：support@geekworm.com

--- a/x-c1-pwr.sh
+++ b/x-c1-pwr.sh
@@ -3,17 +3,11 @@
 SHUTDOWN=4
 REBOOTPULSEMINIMUM=200
 REBOOTPULSEMAXIMUM=600
-echo "$SHUTDOWN" > /sys/class/gpio/export
-echo "in" > /sys/class/gpio/gpio$SHUTDOWN/direction
 BOOT=17
-echo "$BOOT" > /sys/class/gpio/export
-echo "out" > /sys/class/gpio/gpio$BOOT/direction
-echo "1" > /sys/class/gpio/gpio$BOOT/value
-
-echo "Your device are shutting down..."
+gpioset $BOOT=1
 
 while [ 1 ]; do
-  shutdownSignal=$(cat /sys/class/gpio/gpio$SHUTDOWN/value)
+  shutdownSignal=$(gpioget 0 $SHUTDOWN)
   if [ $shutdownSignal = 0 ]; then
     /bin/sleep 0.2
   else
@@ -25,7 +19,7 @@ while [ 1 ]; do
         sudo poweroff
         exit
       fi
-      shutdownSignal=$(cat /sys/class/gpio/gpio$SHUTDOWN/value)
+      shutdownSignal=$(gpioget 0 $SHUTDOWN)
     done
     if [ $(($(date +%s%N | cut -b1-13)-$pulseStart)) -gt $REBOOTPULSEMINIMUM ]; then
       echo "Your device are rebooting", SHUTDOWN, ", recycling Rpi ..."

--- a/x-c1-softsd.sh
+++ b/x-c1-softsd.sh
@@ -2,10 +2,6 @@
 
 BUTTON=27
 
-echo "$BUTTON" > /sys/class/gpio/export;
-echo "out" > /sys/class/gpio/gpio$BUTTON/direction
-echo "1" > /sys/class/gpio/gpio$BUTTON/value
-
 SLEEP=${1:-4}
 
 re='^[0-9\.]+$'
@@ -14,6 +10,5 @@ if ! [[ $SLEEP =~ $re ]] ; then
 fi
 
 echo "Your device will shutting down in 4 seconds..."
-/bin/sleep $SLEEP
 
-echo "0" > /sys/class/gpio/gpio$BUTTON/value
+gpioset --mode=time -s $SLEEP 0 $BUTTON=1


### PR DESCRIPTION
Starting from Ubuntu 22.10, GPIO interface is no longer usable. I've updated the script, to use gpiod instead. This has been tested on a NASPi Gemini 2.5 with Raspberry pi 4 B running on Ubuntu 23.04. 